### PR TITLE
Add Dockerfile with documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:18-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy remaining source
+COPY . .
+
+# Build the extension
+RUN npm run build
+
+# Default command - rebuild on changes
+CMD ["npm", "run", "watch"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Parseltongue uses Webpack to bundle the extension. Follow these steps to compile
     npm run build
     ```
 
+### Build with Docker
+To use Docker for development:
+```bash
+docker build -t parseltongue .
+docker run --rm -it parseltongue
+```
+
+
 
 
 ### Load the Extension


### PR DESCRIPTION
## Summary
- add a Dockerfile to build the extension
- document how to build with Docker in the README

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68409d333b3c8326b426c2dbd27bfad3